### PR TITLE
chore: live leveldb log reader

### DIFF
--- a/core/pkg/leveldb/livereader.go
+++ b/core/pkg/leveldb/livereader.go
@@ -1,0 +1,194 @@
+package leveldb
+
+import (
+	"bytes"
+	"encoding/binary"
+	"errors"
+	"fmt"
+	"io"
+	"os"
+)
+
+// LiveReader reads records from a W&B LevelDB-style log that may be actively written.
+// It is NOT safe for concurrent use.
+type LiveReader struct {
+	// f is the underlying LevelDB-style log.
+	f io.ReaderAt
+	// Cyclic redundancy check function.
+	crc func([]byte) uint32
+	// nextOff is the absolute position where we expect the next record's first chunk header.
+	nextOff int64
+	// processedFirstBlock indicates whether the first block has been read and validated.
+	// The first block needs special handling because of the W&B header.
+	processedFirstBlock bool
+}
+
+func NewLiveReader(r *os.File, algo CRCAlgo) *LiveReader {
+	crc := CRCCustom
+	if algo == CRCAlgoIEEE {
+		crc = CRCStandard
+	}
+	return &LiveReader{f: r, crc: crc}
+}
+
+// VerifyWandbHeader validates the 7-byte W&B file header and positions the reader
+// to the first chunk (offset = 7). After success, Next() starts from there.
+func (r *LiveReader) VerifyWandbHeader(expectedVersion byte) error {
+	if r.processedFirstBlock {
+		return nil
+	}
+	var hdr [wandbHeaderLength]byte
+
+	n, err := r.f.ReadAt(hdr[:], 0)
+	if err != nil && !errors.Is(err, io.EOF) {
+		return fmt.Errorf("livereader: reading W&B header: %w", err)
+	}
+	if n < wandbHeaderLength {
+		// File exists but is not fully initialized yet; treat as incomplete.
+		return io.EOF
+	}
+
+	ident := string(hdr[0:4])
+	magic := uint16(hdr[4]) | uint16(hdr[5])<<8
+	version := hdr[6]
+
+	if ident != wandbHeaderIdent {
+		return fmt.Errorf("livereader: invalid W&B ident: %q", ident)
+	}
+	if magic != wandbHeaderMagic {
+		return fmt.Errorf("livereader: invalid W&B magic: 0x%X", magic)
+	}
+	if version != expectedVersion {
+		return fmt.Errorf("livereader: expected W&B version %d, got %d", expectedVersion, version)
+	}
+
+	r.nextOff = wandbHeaderLength
+	r.processedFirstBlock = true
+	return nil
+}
+
+// Next returns an io.Reader for the next complete record. If no complete record
+// is available *yet* (the file is still being written), it returns io.EOF WITHOUT
+// advancing r.nextOff. Call again when the file grows.
+//
+//gocyclo:ignore
+func (r *LiveReader) Next() (io.Reader, error) {
+	if !r.processedFirstBlock {
+		if err := r.VerifyWandbHeader(0); err != nil {
+			return nil, err
+		}
+	}
+
+	// cur is a transient cursor; commit to nextOff ONLY after we fully build a record.
+	cur := r.nextOff
+
+	var rec bytes.Buffer
+	wantFirst := true
+
+	for {
+		// If not enough bytes for a header in this block, skip to next block boundary.
+		inblock := int(cur & blockSizeMask)
+		if inblock+headerSize > blockSize {
+			cur = (cur &^ int64(blockSizeMask)) + blockSize
+			continue
+		}
+
+		// Read header.
+		var h [headerSize]byte
+		if err := r.readAtExactly(h[:], cur); err != nil {
+			return nil, err
+		}
+		checksum := binary.LittleEndian.Uint32(h[0:4])
+		length := binary.LittleEndian.Uint16(h[4:6])
+		ctype := h[6]
+
+		// Zeroed header often means unused block space (padding) or not-yet-written area.
+		if checksum == 0 && length == 0 && ctype == 0 {
+			// Move to next block boundary (do not commit nextOff).
+			cur = (cur &^ int64(blockSizeMask)) + blockSize
+			continue
+		}
+
+		// Validate chunk type expectations.
+		if wantFirst && ctype != fullChunkType && ctype != firstChunkType {
+			// We expected FULL or FIRST at the start of a record. Since we only ever
+			// start reading at a committed nextOff, this is very unlikely unless the
+			// writer was mid-write. Treat as incomplete.
+			return nil, io.EOF
+		}
+
+		// Check block overflow.
+		blockEnd := (cur &^ int64(blockSizeMask)) + blockSize
+		maxLen := int(blockEnd - (cur + headerSize))
+		if int(length) > maxLen {
+			// A valid writer never produces this. If we see it at the tail, assume incomplete.
+			return nil, io.EOF
+		}
+
+		// Ensure payload fully available in the file.
+		payloadOff := cur + headerSize
+		payloadEnd := payloadOff + int64(length)
+
+		// Read payload.
+		buf := make([]byte, length)
+		if err := r.readAtExactly(buf, payloadOff); err != nil {
+			return nil, err
+		}
+
+		// CRC over [type || payload].
+		crcInput := append([]byte{ctype}, buf...)
+		got := r.crc(crcInput)
+		if got != checksum {
+			// Near the tail this often means "writer hasn't finished"; treat as incomplete.
+			return nil, io.EOF
+		}
+
+		// Accumulate and advance.
+		rec.Write(buf)
+		cur = payloadEnd
+
+		switch ctype {
+		case fullChunkType:
+			// Commit and return.
+			r.nextOff = cur
+			return bytes.NewReader(rec.Bytes()), nil
+
+		case firstChunkType:
+			wantFirst = false
+			// Continue to MIDDLE/LAST.
+
+		case middleChunkType:
+			// Only valid after FIRST.
+			if wantFirst {
+				// Unexpected; treat as incomplete.
+				return nil, io.EOF
+			}
+
+		case lastChunkType:
+			// Record finished; commit and return.
+			r.nextOff = cur
+			return bytes.NewReader(rec.Bytes()), nil
+
+		default:
+			// Unknown type; near the tail, assume incomplete.
+			return nil, io.EOF
+		}
+	}
+}
+
+func (r *LiveReader) readAtExactly(p []byte, off int64) error {
+	n, err := r.f.ReadAt(p, off)
+	switch {
+	case n == len(p):
+		return nil
+	case errors.Is(err, io.ErrUnexpectedEOF):
+		// An EOF is never unexpected: we assume the file may be incomplete.
+		return io.EOF
+	case err != nil:
+		return err
+	default:
+		// By the contract of ReadAt, this is not possible:
+		// err must be non-nil if n != len(p).
+		return errors.New("ReadAt was short but err was nil")
+	}
+}

--- a/core/pkg/leveldb/livereader_test.go
+++ b/core/pkg/leveldb/livereader_test.go
@@ -1,0 +1,226 @@
+package leveldb_test
+
+import (
+	"bytes"
+	"io"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	"github.com/wandb/wandb/core/pkg/leveldb"
+)
+
+const (
+	blockSize         = 32 * 1024
+	headerSize        = 7
+	wandbHeaderLength = 7
+)
+
+// encodeRecords serializes one or more records using the W&B writer with the
+// given CRC algorithm and W&B header version.
+func encodeRecords(t *testing.T, algo leveldb.CRCAlgo, version byte, recs ...[]byte) []byte {
+	t.Helper()
+	var buf bytes.Buffer
+	w := leveldb.NewWriterExt(&buf, algo, version)
+	for _, r := range recs {
+		ww, err := w.Next()
+		require.NoError(t, err)
+		_, err = ww.Write(r)
+		require.NoError(t, err)
+	}
+	err := w.Close()
+	require.NoError(t, err)
+	return buf.Bytes()
+}
+
+func openLiveFiles(t *testing.T) (path string, w *os.File, r *os.File) {
+	t.Helper()
+	dir := t.TempDir()
+	path = filepath.Join(dir, "live.wandb")
+	// Writer handle (append).
+	wh, err := os.OpenFile(path, os.O_CREATE|os.O_WRONLY|os.O_TRUNC, 0o600)
+	require.NoError(t, err)
+	// Reader handle (ReadAt).
+	rh, err := os.Open(path)
+	require.NoError(t, err)
+	t.Cleanup(func() {
+		_ = wh.Close()
+		_ = rh.Close()
+	})
+	return path, wh, rh
+}
+
+func appendAndSync(t *testing.T, w *os.File, p []byte) {
+	t.Helper()
+	if len(p) == 0 {
+		return
+	}
+	_, err := w.Write(p)
+	require.NoError(t, err)
+
+	err = w.Sync()
+	require.NoError(t, err)
+}
+
+func readAll(t *testing.T, r io.Reader) []byte {
+	t.Helper()
+	b, err := io.ReadAll(r)
+	require.NoError(t, err)
+	return b
+}
+
+func TestLiveReader_PartialHeaderAndPayload(t *testing.T) {
+	// Partial W&B header, then partial chunk header, then partial payload.
+	// Next() must return io.EOF until the complete record is available.
+
+	_, w, rf := openLiveFiles(t)
+
+	// One small record.
+	payload := []byte("hello world")
+	stream := encodeRecords(t, leveldb.CRCAlgoCustom, 0, payload)
+
+	lr := leveldb.NewLiveReader(rf, leveldb.CRCAlgoCustom)
+
+	// 0. Empty file -> soft EOF.
+	_, err := lr.Next()
+	require.ErrorIs(t, err, io.EOF)
+
+	// 1. Write partial W&B header (3 bytes).
+	appendAndSync(t, w, stream[:3])
+	_, err = lr.Next()
+	require.ErrorIs(t, err, io.EOF)
+
+	// 2. Finish W&B header (bytes 3..6).
+	appendAndSync(t, w, stream[3:7])
+	_, err = lr.Next()
+	require.ErrorIs(t, err, io.EOF)
+
+	// 3. Write partial chunk header (7..10).
+	appendAndSync(t, w, stream[7:10])
+	_, err = lr.Next()
+	require.ErrorIs(t, err, io.EOF)
+
+	// 4. Finish chunk header (10..14).
+	appendAndSync(t, w, stream[10:14])
+	_, err = lr.Next()
+	require.ErrorIs(t, err, io.EOF)
+
+	// 5. Write all payload except the last byte.
+	appendAndSync(t, w, stream[14:len(stream)-1])
+	_, err = lr.Next()
+	require.ErrorIs(t, err, io.EOF)
+
+	// 6. Write last byte -> record should be readable now.
+	appendAndSync(t, w, stream[len(stream)-1:])
+	rdr, err := lr.Next()
+	require.NoError(t, err)
+	got := readAll(t, rdr)
+	require.Equal(t, got, payload)
+}
+
+func TestLiveReader_DoesNotSkipGoodRecordWhenNextIsIncomplete(t *testing.T) {
+	// Do not skip a good record when the following one is incomplete.
+	_, w, rf := openLiveFiles(t)
+
+	recA := bytes.Repeat([]byte("A"), 1000)
+	recB := bytes.Repeat([]byte("B"), 1000)
+	stream := encodeRecords(t, leveldb.CRCAlgoCustom, 0, recA, recB)
+
+	lr := leveldb.NewLiveReader(rf, leveldb.CRCAlgoCustom)
+
+	// Write everything except the very last byte of recB.
+	appendAndSync(t, w, stream[:len(stream)-1])
+
+	// Should read recA successfully.
+	rdr, err := lr.Next()
+	require.NoError(t, err)
+	gotA := readAll(t, rdr)
+	require.Equal(t, recA, gotA)
+
+	// recB is incomplete -> io.EOF (soft).
+	_, err = lr.Next()
+	require.ErrorIs(t, err, io.EOF)
+
+	// Append the final byte; recB should be returned on the next call.
+	appendAndSync(t, w, stream[len(stream)-1:])
+	rdr, err = lr.Next()
+	require.NoError(t, err)
+	gotB := readAll(t, rdr)
+	require.Equal(t, recB, gotB)
+}
+
+func TestLiveReader_MultiChunkRecord_PartialThenComplete(t *testing.T) {
+	// One very large record spanning multiple blocks. With the tail missing,
+	// Next() must soft-EOF; after appending the final byte, it must return the record.
+
+	_, w, rf := openLiveFiles(t)
+
+	// ~2.5 blocks to guarantee FIRST/MIDDLE/LAST chunking.
+	long := bytes.Repeat([]byte{0xAB}, blockSize*2+1000)
+	stream := encodeRecords(t, leveldb.CRCAlgoCustom, 0, long)
+
+	lr := leveldb.NewLiveReader(rf, leveldb.CRCAlgoCustom)
+
+	// Write everything except last byte of the whole stream.
+	appendAndSync(t, w, stream[:len(stream)-1])
+
+	// No complete record yet -> soft EOF.
+	_, err := lr.Next()
+	require.ErrorIs(t, err, io.EOF)
+
+	// Finish the file.
+	appendAndSync(t, w, stream[len(stream)-1:])
+	rdr, err := lr.Next()
+	require.NoError(t, err)
+	got := readAll(t, rdr)
+	require.Equal(t, len(got), len(long))
+	require.Equal(t, got[:64], long[:64])
+	require.Equal(t, got[len(got)-64:], long[len(long)-64:])
+}
+
+func TestLiveReader_SkipBlockTailPaddingToNextBlock(t *testing.T) {
+	// Block tail padding. First record leaves <7 bytes in the first block,
+	// so the next record starts in the next block. Write exactly one block first,
+	// then verify the first record is readable, the next is not, and only becomes
+	// readable once the next block is appended.
+
+	_, w, rf := openLiveFiles(t)
+
+	// First record leaves 3 bytes at end-of-block:
+	// payload L1 = blockSize - W&B header - chunk header - 3.
+	L1 := blockSize - wandbHeaderLength - headerSize - 3
+	rec1 := bytes.Repeat([]byte("X"), L1)
+	rec2 := bytes.Repeat([]byte("Y"), 100)
+
+	stream := encodeRecords(t, leveldb.CRCAlgoCustom, 0, rec1, rec2)
+
+	// Sanity: we expect the first block to be fully occupied after rec1 (+3 zero bytes).
+	if len(stream) < blockSize+headerSize+len(rec2) {
+		t.Fatalf("unexpected stream shape; got %d bytes", len(stream))
+	}
+
+	lr := leveldb.NewLiveReader(rf, leveldb.CRCAlgoCustom)
+
+	// Write exactly one full block.
+	appendAndSync(t, w, stream[:blockSize])
+
+	// rec1 should be readable.
+	rdr, err := lr.Next()
+	require.NoError(t, err)
+	got1 := readAll(t, rdr)
+	require.Equal(t, len(got1), len(rec1))
+
+	// rec2 lives in the next block -> soft EOF until we append that block.
+	_, err = lr.Next()
+	require.ErrorIs(t, err, io.EOF)
+
+	// Append the remainder of the stream (starting at the second block).
+	appendAndSync(t, w, stream[blockSize:])
+
+	// Now rec2 should be returned.
+	rdr, err = lr.Next()
+	require.NoError(t, err)
+	got2 := readAll(t, rdr)
+	require.Equal(t, rec2, got2)
+}


### PR DESCRIPTION
Recreated from original PR: https://github.com/wandb/wandb/pull/10572

Description
-----------
This PR implements a `LiveReader` struct to read records from a W&B LevelDB-style log that may be actively written.

Intentionally kept separate from the battle-tested implementation of leveldb log reader/writer used in `wandb-core`.